### PR TITLE
fix: 公式画像の取得枚数を3枚に制限

### DIFF
--- a/src/hooks/use-map.ts
+++ b/src/hooks/use-map.ts
@@ -261,10 +261,9 @@ export const useMap = (): ReturnType => {
     )
       .then((res) => res.json())
       .then((res) => {
-        console.log(res)
         if (res.photos != null) {
           // @ts-ignore
-          res.photos.map((photo) => {
+          res.photos.slice(0, 3).map((photo) => {
             fetch(
               `https://places.googleapis.com/v1/${photo.name}/media?key=${process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY}&maxWidthPx=400`,
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
  - フォトギャラリーの表示ロジックを変更し、最初の3枚の写真のみを表示するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->